### PR TITLE
Enable Bluetooth auto-discovery for Swissinno BLE

### DIFF
--- a/custom_components/swissinno_ble/config_flow.py
+++ b/custom_components/swissinno_ble/config_flow.py
@@ -3,8 +3,10 @@ import re
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.const import CONF_MAC, CONF_NAME
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import format_mac
 
 from .const import DOMAIN
 
@@ -13,11 +15,14 @@ class SwissinnoBLEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    def __init__(self) -> None:
+        self._discovery_info: BluetoothServiceInfoBleak | None = None
+
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            mac_address = user_input[CONF_MAC]
+            mac_address = format_mac(user_input[CONF_MAC])
             name = user_input[CONF_NAME]
 
             if not self._valid_mac(mac_address):
@@ -36,8 +41,18 @@ class SwissinnoBLEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         data_schema = vol.Schema(
             {
-                vol.Required(CONF_NAME, default="Swissinno Mouse Trap"): str,
-                vol.Required(CONF_MAC): str,
+                vol.Required(
+                    CONF_NAME,
+                    default=(self._discovery_info.name if self._discovery_info else "Swissinno Mouse Trap"),
+                ): str,
+                vol.Required(
+                    CONF_MAC,
+                    default=(
+                        format_mac(self._discovery_info.address)
+                        if self._discovery_info
+                        else ""
+                    ),
+                ): str,
             }
         )
 
@@ -46,6 +61,14 @@ class SwissinnoBLEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=data_schema,
             errors=errors,
         )
+
+    async def async_step_bluetooth(self, discovery_info: BluetoothServiceInfoBleak):
+        """Handle a bluetooth discovery flow."""
+        await self.async_set_unique_id(format_mac(discovery_info.address), raise_on_progress=False)
+        self._abort_if_unique_id_configured()
+        self._discovery_info = discovery_info
+        self.context["title_placeholders"] = {"name": discovery_info.name or "Swissinno Mouse Trap"}
+        return await self.async_step_user()
 
     @staticmethod
     @callback

--- a/custom_components/swissinno_ble/manifest.json
+++ b/custom_components/swissinno_ble/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "swissinno_ble",
   "name": "Swissinno BLE",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "documentation": "https://github.com/yourusername/swissinno_BLE",
   "requirements": [
     "bleak>=0.20.2"


### PR DESCRIPTION
## Summary
- support Bluetooth discovery in config flow
- normalize MAC addresses with `format_mac`
- bump integration version to 1.0.1

## Testing
- `python -m py_compile custom_components/swissinno_ble/config_flow.py`
- `python -m json.tool custom_components/swissinno_ble/manifest.json >/dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68b300ede614832fa0aa4fed41436502