### PR TITLE
Fix Swissinno BLE availability and options flow deprecation

### DIFF
--- a/custom_components/swissinno_ble/config_flow.py
+++ b/custom_components/swissinno_ble/config_flow.py
@@ -83,9 +83,6 @@ class SwissinnoBLEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class SwissinnoBLEOptionsFlow(config_entries.OptionsFlow):
     """Handle options flow for Swissinno BLE."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        self.config_entry = config_entry
-
     async def async_step_init(self, user_input=None):
         """Manage the options."""
         return await self.async_step_user()

--- a/custom_components/swissinno_ble/sensor.py
+++ b/custom_components/swissinno_ble/sensor.py
@@ -36,7 +36,7 @@ class SwissinnoBLESensor(SensorEntity):
         self._hass = hass
         self._address = address
         self._name = f"{name} Status"
-        self._state: str | None = None
+        self._state: str | None = "Not triggered"
         self._attr_should_poll = False
         self._attr_unique_id = f"{self._address}_status"
         self._attr_device_info = DeviceInfo(
@@ -51,7 +51,7 @@ class SwissinnoBLESensor(SensorEntity):
             {"address": self._address},
             BluetoothScanningMode.ACTIVE,
         )
-        self._last_seen: float | None = None
+        self._last_seen: float | None = self._hass.loop.time()
 
     @callback
     def _async_handle_ble_event(


### PR DESCRIPTION
## Summary
- Remove deprecated direct assignment to `config_entry` in options flow
- Initialize trap sensor with a default state and last-seen timestamp so it isn't stuck as unavailable

## Testing
- `python -m py_compile custom_components/swissinno_ble/config_flow.py custom_components/swissinno_ble/sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b303203bf0832f9fd025611b27ec5f