### PR TITLE
Fix reset button coroutine usage

### DIFF
--- a/custom_components/swissinno_ble/button.py
+++ b/custom_components/swissinno_ble/button.py
@@ -56,9 +56,13 @@ class SwissinnoResetButton(ButtonEntity):
         try:
             from bleak import BleakClient
 
-            async with BleakClient(self._address) as client:
+            client = BleakClient(self._address)
+            try:
+                await client.connect()
                 await client.write_gatt_char(RESET_CHAR_UUID, b"\x00")
                 _LOGGER.debug("Reset command sent to %s", self._address)
+            finally:
+                await client.disconnect()
 
         except Exception as err:
             _LOGGER.error("Error resetting the mouse trap: %s", err)


### PR DESCRIPTION
## Summary
- avoid using async context manager for BLE reset
- connect/write/disconnect manually to fix NoneType await errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b30f255038832f981556cfa515980e