### PR TITLE
Use correct Swissinno trap characteristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ trap status and provides a button to remotely reset the trap.
 2. Click **Add Integration** and search for "Swissinno BLE".
 3. Enter the name and MAC address of your trap.
 
+## BLE details
+
+- The first byte of the Swissinno manufacturer data is `0x00` when the trap is
+  not triggered and `0x01` when triggered.
+- Resetting the trap is done by writing `0x00` to characteristic
+  `02ecc6cd-2b43-4db5-96e6-ede92cf8778d` (`0x01` indicates a triggered state).
+- The trap name can be read and written via characteristic
+  `02ecc6cd-2b43-4db5-96e6-ede92cf8778b`.
+
 ## Notes
 
 - Requires Bluetooth support on the host running Home Assistant.

--- a/custom_components/swissinno_ble/const.py
+++ b/custom_components/swissinno_ble/const.py
@@ -6,6 +6,10 @@ MANUFACTURER_IDS = [0xBB0B, 0x0BBB]
 # Time in seconds after which the sensor is marked as unavailable
 UNAVAILABLE_AFTER_SECS = 600  # 10 minutes
 
+# GATT characteristic holding the trap name
+NAME_CHAR_UUID = "02ecc6cd-2b43-4db5-96e6-ede92cf8778b"
+
 # GATT characteristic used to reset the trap
-RESET_CHAR_UUID = "0000ff01-0000-1000-8000-00805f9b34fb"
+# Write 0x00 to mark the trap as not triggered (0x01 means triggered)
+RESET_CHAR_UUID = "02ecc6cd-2b43-4db5-96e6-ede92cf8778d"
 


### PR DESCRIPTION
## Summary
- Document manufacturer data and GATT characteristics used by Swissinno traps
- Switch reset characteristic to 02ecc6cd-2b43-4db5-96e6-ede92cf8778d
- Add constant for trap name characteristic

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5e481240c832f9b1c3b3fb80b9594