### PR TITLE
Use proper BLE device lookup and guard sensor state updates

### DIFF
--- a/custom_components/swissinno_ble/button.py
+++ b/custom_components/swissinno_ble/button.py
@@ -1,6 +1,7 @@
 import logging
 
 from homeassistant.components.button import ButtonEntity
+from homeassistant.components.bluetooth import async_ble_device_from_address
 from homeassistant.components.persistent_notification import (
     async_create as async_create_persistent_notification,
 )
@@ -53,22 +54,28 @@ class SwissinnoResetButton(ButtonEntity):
 
     async def async_press(self):
         """Handle the button press."""
-        try:
-            from bleak import BleakClient
+        from bleak import BleakClient
+        from bleak.exc import BleakError
 
-            client = BleakClient(self._address)
-            try:
-                await client.connect()
+        device = async_ble_device_from_address(
+            self.hass, self._address, connectable=True
+        )
+        if not device:
+            msg = f"Bluetooth device with address {self._address} not found"
+            _LOGGER.error(msg)
+            await async_create_persistent_notification(
+                self.hass, msg, title="Swissinno Mouse Trap"
+            )
+            return
+
+        try:
+            async with BleakClient(device) as client:
                 await client.write_gatt_char(RESET_CHAR_UUID, b"\x00")
                 _LOGGER.debug("Reset command sent to %s", self._address)
-            finally:
-                await client.disconnect()
-
-        except Exception as err:
-            _LOGGER.error("Error resetting the mouse trap: %s", err)
+        except BleakError as err:
+            msg = f"Failed to reset mouse trap {self._name}: {err}"
+            _LOGGER.error(msg)
             await async_create_persistent_notification(
-                self.hass,
-                f"Error resetting mouse trap {self._name}: {err}",
-                title="Swissinno Mouse Trap",
+                self.hass, msg, title="Swissinno Mouse Trap"
             )
 

--- a/custom_components/swissinno_ble/sensor.py
+++ b/custom_components/swissinno_ble/sensor.py
@@ -106,6 +106,11 @@ class SwissinnoBLESensor(SensorEntity):
 
         self._state = state
         self._last_seen = self._hass.loop.time()
+        if self.hass is None:
+            _LOGGER.debug(
+                "Entity not yet added to Home Assistant; skipping state update"
+            )
+            return
         self.async_write_ha_state()
 
     @property


### PR DESCRIPTION
## Summary
- Retrieve BLE devices using `async_ble_device_from_address` before connecting
- Guard sensor BLE callback until entity added to Home Assistant

## Testing
- `python -m py_compile custom_components/swissinno_ble/button.py custom_components/swissinno_ble/sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b65eafe738832f96f2eda63c3d4fcd