### PR TITLE
Clarify Swissinno BLE project is unofficial hobby effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
-# Swissinno BLE
+# Swissinno BLE (Unofficial)
 
-Home Assistant integration for [Swissinno](https://www.swissinno.com/) Bluetooth
-mouse traps. The integration listens for Bluetooth advertisements to monitor the
-trap status and provides a button to remotely reset the trap.
+![Project Logo](images/project.svg)
+
+**Disclaimer:** This is a hobby project and is not affiliated with, endorsed by,
+or supported by Swissinno AG. Swissinno is a trademark of its respective owner,
+and the name is used here solely for identification purposes. No guarantees or
+warranties are provided.
+
+Home Assistant integration for Swissinno Bluetooth mouse traps. The integration
+listens for Bluetooth advertisements to monitor the trap status and provides a
+button to remotely reset the trap.
 
 ## Features
 
@@ -15,7 +22,7 @@ trap status and provides a button to remotely reset the trap.
 ### HACS (recommended)
 
 1. Add this repository as a custom repository in HACS.
-2. Install the **Swissinno BLE** integration from HACS.
+2. Install the **Swissinno BLE (Unofficial)** integration from HACS.
 3. Restart Home Assistant.
 
 ### Manual
@@ -27,7 +34,7 @@ trap status and provides a button to remotely reset the trap.
 ## Configuration
 
 1. In Home Assistant go to **Settings → Devices & services**.
-2. Click **Add Integration** and search for "Swissinno BLE".
+2. Click **Add Integration** and search for "Swissinno BLE (Unofficial)".
 3. Enter the name and MAC address of your trap.
 
 ## BLE details

--- a/custom_components/swissinno_ble/__init__.py
+++ b/custom_components/swissinno_ble/__init__.py
@@ -1,4 +1,8 @@
-"""Swissinno BLE integration."""
+"""Unofficial Swissinno BLE integration for Home Assistant.
+
+This hobby project is not affiliated with Swissinno AG and is provided without
+any guarantees. Swissinno is a trademark of its respective owner.
+"""
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/custom_components/swissinno_ble/button.py
+++ b/custom_components/swissinno_ble/button.py
@@ -1,3 +1,9 @@
+"""Unofficial Swissinno BLE reset button for Home Assistant.
+
+This hobby project is not affiliated with Swissinno AG and is provided without
+any guarantees. Swissinno is a trademark of its respective owner.
+"""
+
 import logging
 
 from homeassistant.components.button import ButtonEntity
@@ -38,8 +44,8 @@ class SwissinnoResetButton(ButtonEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._address)},
             name=name,
-            manufacturer="Swissinno",
-            model="Swissinno Mouse Trap",
+            manufacturer="Swissinno (unofficial)",
+            model="Mouse Trap",
         )
 
     @property
@@ -64,7 +70,7 @@ class SwissinnoResetButton(ButtonEntity):
             msg = f"Bluetooth device with address {self._address} not found"
             _LOGGER.error(msg)
             await async_create_persistent_notification(
-                self.hass, msg, title="Swissinno Mouse Trap"
+                self.hass, msg, title="Mouse Trap"
             )
             return
 
@@ -76,6 +82,6 @@ class SwissinnoResetButton(ButtonEntity):
             msg = f"Failed to reset mouse trap {self._name}: {err}"
             _LOGGER.error(msg)
             await async_create_persistent_notification(
-                self.hass, msg, title="Swissinno Mouse Trap"
+                self.hass, msg, title="Mouse Trap"
             )
 

--- a/custom_components/swissinno_ble/config_flow.py
+++ b/custom_components/swissinno_ble/config_flow.py
@@ -1,3 +1,9 @@
+"""Config flow for the unofficial Swissinno BLE integration.
+
+This hobby project is not affiliated with Swissinno AG and is provided without
+any guarantees. Swissinno is a trademark of its respective owner.
+"""
+
 import re
 
 import voluptuous as vol
@@ -43,7 +49,7 @@ class SwissinnoBLEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(
                     CONF_NAME,
-                    default=(self._discovery_info.name if self._discovery_info else "Swissinno Mouse Trap"),
+                    default=(self._discovery_info.name if self._discovery_info else "Mouse Trap"),
                 ): str,
                 vol.Required(
                     CONF_MAC,
@@ -67,7 +73,7 @@ class SwissinnoBLEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(format_mac(discovery_info.address), raise_on_progress=False)
         self._abort_if_unique_id_configured()
         self._discovery_info = discovery_info
-        self.context["title_placeholders"] = {"name": discovery_info.name or "Swissinno Mouse Trap"}
+        self.context["title_placeholders"] = {"name": discovery_info.name or "Mouse Trap"}
         return await self.async_step_user()
 
     @staticmethod

--- a/custom_components/swissinno_ble/const.py
+++ b/custom_components/swissinno_ble/const.py
@@ -1,3 +1,9 @@
+"""Constants for the unofficial Swissinno BLE integration.
+
+This hobby project is not affiliated with Swissinno AG and is provided without
+any guarantees. Swissinno is a trademark of its respective owner.
+"""
+
 DOMAIN = "swissinno_ble"
 
 # Manufacturer IDs for Swissinno devices

--- a/custom_components/swissinno_ble/manifest.json
+++ b/custom_components/swissinno_ble/manifest.json
@@ -1,14 +1,14 @@
 {
   "domain": "swissinno_ble",
-  "name": "Swissinno BLE",
+  "name": "Swissinno BLE (Unofficial)",
   "version": "1.0.1",
   "documentation": "https://github.com/yourusername/swissinno_BLE",
+  "issue_tracker": "https://github.com/yourusername/swissinno_BLE/issues",
   "requirements": [
     "bleak>=0.20.2"
   ],
   "dependencies": ["bluetooth"],
   "codeowners": ["@yourusername"],
-  "issue_tracker": "https://github.com/yourusername/swissinno_BLE/issues",
   "config_flow": true,
   "iot_class": "local_push",
   "bluetooth": [

--- a/custom_components/swissinno_ble/sensor.py
+++ b/custom_components/swissinno_ble/sensor.py
@@ -1,3 +1,9 @@
+"""Unofficial Swissinno BLE sensor for Home Assistant.
+
+This hobby project is not affiliated with Swissinno AG and is provided without
+any guarantees. Swissinno is a trademark of its respective owner.
+"""
+
 import logging
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.bluetooth import (
@@ -43,8 +49,8 @@ class SwissinnoBLESensor(SensorEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._address)},
             name=name,
-            manufacturer="Swissinno",
-            model="Swissinno Mouse Trap",
+            manufacturer="Swissinno (unofficial)",
+            model="Mouse Trap",
         )
         # Devices rotate their Bluetooth addresses for privacy which would make
         # an address based filter miss advertisements. Instead we match on the

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Swissinno BLE",
+  "name": "Swissinno BLE (Unofficial)",
   "render_readme": true,
   "homeassistant": "2024.1.0"
 }

--- a/images/project.svg
+++ b/images/project.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="60" y="20" fill="#cccccc" stroke="#000000"/>
+  <line x1="0" y1="20" x2="100" y2="20" stroke="#000000"/>
+  <circle cx="50" cy="50" r="10" fill="#999999" stroke="#000000"/>
+</svg>


### PR DESCRIPTION
## Summary
- Add prominent disclaimer stating project is a hobby and unaffiliated with Swissinno AG
- Replace manufacturer details and notifications with generic names and include new neutral logo
- Rename integration in metadata to "Swissinno BLE (Unofficial)"

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b6645117b0832fb749ec7cca5cfa8d