### PR TITLE
Fix reset button by removing invalid await on device lookup

### DIFF
--- a/custom_components/swissinno_ble/button.py
+++ b/custom_components/swissinno_ble/button.py
@@ -21,6 +21,7 @@ from .const import DOMAIN, RESET_CHAR_UUID
 
 _LOGGER = logging.getLogger(__name__)
 
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -32,6 +33,7 @@ async def async_setup_entry(
 
     button = SwissinnoResetButton(name, address)
     async_add_entities([button])
+
 
 class SwissinnoResetButton(ButtonEntity):
     """Representation of the Swissinno BLE reset button."""
@@ -63,7 +65,7 @@ class SwissinnoResetButton(ButtonEntity):
         from bleak import BleakClient
         from bleak.exc import BleakError
 
-        device = await async_ble_device_from_address(
+        device = async_ble_device_from_address(
             self.hass, self._address, connectable=True
         )
         if not device:
@@ -84,4 +86,3 @@ class SwissinnoResetButton(ButtonEntity):
             await async_create_persistent_notification(
                 self.hass, msg, title="Mouse Trap"
             )
-


### PR DESCRIPTION
## Summary
- fix reset button by removing await on async_ble_device_from_address

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b66a46756c832f8ed76b6c5d6d5df8