### PR TITLE
Expose battery voltage sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ button to remotely reset the trap.
   `02ecc6cd-2b43-4db5-96e6-ede92cf8778d` (`0x01` indicates a triggered state).
 - The trap name can be read and written via characteristic
   `02ecc6cd-2b43-4db5-96e6-ede92cf8778b`.
+- Manufacturer data also contains the trap's battery voltage. Examples:
+  - `0x0201060303D6FC0DFFBB0B001AAC12030001B80100` → 2.6 V
+  - `0x0201060303D6FC0DFFBB0B001DAC12030001CA0100` → 2.85 V
+  - `0x0201060303D6FC0DFFBB0B001FAC12030001DA0100` → 3.08 V
+  - Bytes 7–8 (zero-indexed) of the manufacturer data form a little-endian
+    value used to calculate the battery voltage via `(raw - 253) / 72`. The
+    integration exposes **Battery Voltage** and **Battery** sensors which show
+    the voltage and an approximate percentage (2.0 V empty, 3.2 V full).
 
 ## Notes
 

--- a/custom_components/swissinno_ble/const.py
+++ b/custom_components/swissinno_ble/const.py
@@ -12,6 +12,10 @@ MANUFACTURER_IDS = [0xBB0B, 0x0BBB]
 # Time in seconds after which the sensor is marked as unavailable
 UNAVAILABLE_AFTER_SECS = 600  # 10 minutes
 
+# Battery voltage range used for percentage calculation
+BATTERY_MIN_VOLTAGE = 2.0
+BATTERY_MAX_VOLTAGE = 3.2
+
 # GATT characteristic holding the trap name
 NAME_CHAR_UUID = "02ecc6cd-2b43-4db5-96e6-ede92cf8778b"
 

--- a/custom_components/swissinno_ble/sensor.py
+++ b/custom_components/swissinno_ble/sensor.py
@@ -1,11 +1,13 @@
-"""Unofficial Swissinno BLE sensor for Home Assistant.
+"""Unofficial Swissinno BLE sensors for Home Assistant.
 
 This hobby project is not affiliated with Swissinno AG and is provided without
 any guarantees. Swissinno is a trademark of its respective owner.
 """
 
+from __future__ import annotations
+
 import logging
-from homeassistant.components.sensor import SensorEntity
+
 from homeassistant.components.bluetooth import (
     BluetoothCallbackMatcher,
     BluetoothChange,
@@ -13,49 +15,92 @@ from homeassistant.components.bluetooth import (
     BluetoothServiceInfoBleak,
     async_register_callback,
 )
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_MAC, CONF_NAME
+from homeassistant.const import (
+    CONF_MAC,
+    CONF_NAME,
+    PERCENTAGE,
+    UnitOfElectricPotential,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, MANUFACTURER_IDS, UNAVAILABLE_AFTER_SECS
+from .const import (
+    BATTERY_MAX_VOLTAGE,
+    BATTERY_MIN_VOLTAGE,
+    DOMAIN,
+    MANUFACTURER_IDS,
+    UNAVAILABLE_AFTER_SECS,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Swissinno BLE sensor based on a config entry."""
+    """Set up Swissinno BLE sensors based on a config entry."""
     address = config_entry.data[CONF_MAC].lower()
     name = config_entry.data[CONF_NAME]
 
-    sensor = SwissinnoBLESensor(hass, address, name)
-    async_add_entities([sensor])
+    sensors = [
+        SwissinnoBLEStatusSensor(hass, address, name),
+        SwissinnoBLEVoltageSensor(hass, address, name),
+        SwissinnoBLEBatterySensor(hass, address, name),
+    ]
+    async_add_entities(sensors)
 
-class SwissinnoBLESensor(SensorEntity):
-    """Representation of a Swissinno BLE sensor."""
 
-    def __init__(self, hass: HomeAssistant, address: str, name: str) -> None:
-        """Initialize the sensor."""
+def _parse_battery_raw(manufacturer_data: bytes) -> int | None:
+    """Return the raw battery reading from manufacturer data."""
+    if len(manufacturer_data) < 9:
+        return None
+    return int.from_bytes(manufacturer_data[7:9], "little")
+
+
+def _raw_to_voltage(raw: int) -> float:
+    """Convert the raw battery reading to volts."""
+    return round((raw - 253) / 72, 2)
+
+
+def _voltage_to_percentage(voltage: float) -> int:
+    """Convert a voltage reading to a battery percentage."""
+    percent = (voltage - BATTERY_MIN_VOLTAGE) / (
+        BATTERY_MAX_VOLTAGE - BATTERY_MIN_VOLTAGE
+    ) * 100
+    return max(0, min(100, round(percent)))
+
+
+class SwissinnoBLEEntity(SensorEntity):
+    """Base class for Swissinno BLE entities."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        address: str,
+        name: str,
+        name_suffix: str,
+        unique_suffix: str,
+    ) -> None:
         self._hass = hass
         self._address = address
-        self._name = f"{name} Status"
-        self._state: str | None = "Not triggered"
+        self._name = f"{name} {name_suffix}"
         self._attr_should_poll = False
-        self._attr_unique_id = f"{self._address}_status"
+        self._attr_unique_id = f"{self._address}_{unique_suffix}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._address)},
             name=name,
             manufacturer="Swissinno (unofficial)",
             model="Mouse Trap",
         )
-        # Devices rotate their Bluetooth addresses for privacy which would make
-        # an address based filter miss advertisements. Instead we match on the
-        # manufacturer ID which remains constant for our traps and provides a
-        # stable way to identify them.
         self._unsub = [
             async_register_callback(
                 hass,
@@ -69,9 +114,7 @@ class SwissinnoBLESensor(SensorEntity):
 
     @callback
     def _async_handle_ble_event(
-        self,
-        service_info: BluetoothServiceInfoBleak,
-        change: BluetoothChange,
+        self, service_info: BluetoothServiceInfoBleak, change: BluetoothChange
     ) -> None:
         """Process a Bluetooth event."""
         _LOGGER.debug("Advertisement from %s: %s", service_info.address, service_info)
@@ -86,9 +129,6 @@ class SwissinnoBLESensor(SensorEntity):
                 )
                 break
 
-        # Even though the callback was registered with a manufacturer filter,
-        # verify the manufacturer data to avoid processing packets from
-        # unrelated devices.
         if not manufacturer_data:
             _LOGGER.debug(
                 "No manufacturer data with IDs %s found",
@@ -96,21 +136,7 @@ class SwissinnoBLESensor(SensorEntity):
             )
             return
 
-        if len(manufacturer_data) < 1:
-            _LOGGER.debug("Manufacturer data is too short")
-            return
-
-        status_byte = manufacturer_data[0]
-        _LOGGER.debug("Status byte: 0x%02X", status_byte)
-
-        if status_byte == 0x00:
-            state = "Not triggered"
-        elif status_byte == 0x01:
-            state = "Triggered"
-        else:
-            state = f"Unknown status: 0x{status_byte:02X}"
-
-        self._state = state
+        self._handle_data(manufacturer_data)
         self._last_seen = self._hass.loop.time()
         if self.hass is None:
             _LOGGER.debug(
@@ -119,15 +145,13 @@ class SwissinnoBLESensor(SensorEntity):
             return
         self.async_write_ha_state()
 
+    def _handle_data(self, manufacturer_data: bytes) -> None:
+        """Handle manufacturer data."""
+
     @property
     def name(self) -> str:
         """Return the name of the sensor."""
         return self._name
-
-    @property
-    def native_value(self) -> str | None:
-        """Return the current status."""
-        return self._state
 
     @property
     def available(self) -> bool:
@@ -142,4 +166,80 @@ class SwissinnoBLESensor(SensorEntity):
             for unsub in self._unsub:
                 unsub()
             self._unsub = None
+
+
+class SwissinnoBLEStatusSensor(SwissinnoBLEEntity):
+    """Representation of the trap status."""
+
+    def __init__(self, hass: HomeAssistant, address: str, name: str) -> None:
+        super().__init__(hass, address, name, "Status", "status")
+        self._state: str | None = "Not triggered"
+
+    def _handle_data(self, manufacturer_data: bytes) -> None:
+        if len(manufacturer_data) < 1:
+            _LOGGER.debug("Manufacturer data is too short")
+            return
+
+        status_byte = manufacturer_data[0]
+        _LOGGER.debug("Status byte: 0x%02X", status_byte)
+
+        if status_byte == 0x00:
+            self._state = "Not triggered"
+        elif status_byte == 0x01:
+            self._state = "Triggered"
+        else:
+            self._state = f"Unknown status: 0x{status_byte:02X}"
+
+    @property
+    def native_value(self) -> str | None:
+        return self._state
+
+
+class SwissinnoBLEVoltageSensor(SwissinnoBLEEntity):
+    """Representation of the trap battery voltage."""
+
+    def __init__(self, hass: HomeAssistant, address: str, name: str) -> None:
+        super().__init__(hass, address, name, "Battery Voltage", "voltage")
+        self._attr_device_class = SensorDeviceClass.VOLTAGE
+        self._attr_native_unit_of_measurement = UnitOfElectricPotential.VOLT
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._voltage: float | None = None
+
+    def _handle_data(self, manufacturer_data: bytes) -> None:
+        raw = _parse_battery_raw(manufacturer_data)
+        if raw is None:
+            _LOGGER.debug("Manufacturer data is too short")
+            return
+        self._voltage = _raw_to_voltage(raw)
+        _LOGGER.debug("Battery raw %s -> %.2f V", raw, self._voltage)
+
+    @property
+    def native_value(self) -> float | None:
+        return self._voltage
+
+
+class SwissinnoBLEBatterySensor(SwissinnoBLEEntity):
+    """Representation of the trap battery percentage."""
+
+    def __init__(self, hass: HomeAssistant, address: str, name: str) -> None:
+        super().__init__(hass, address, name, "Battery", "battery")
+        self._attr_device_class = SensorDeviceClass.BATTERY
+        self._attr_native_unit_of_measurement = PERCENTAGE
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._percentage: int | None = None
+
+    def _handle_data(self, manufacturer_data: bytes) -> None:
+        raw = _parse_battery_raw(manufacturer_data)
+        if raw is None:
+            _LOGGER.debug("Manufacturer data is too short")
+            return
+        voltage = _raw_to_voltage(raw)
+        self._percentage = _voltage_to_percentage(voltage)
+        _LOGGER.debug(
+            "Battery raw %s -> %.2f V -> %d%%", raw, voltage, self._percentage
+        )
+
+    @property
+    def native_value(self) -> int | None:
+        return self._percentage
 


### PR DESCRIPTION
## Summary
- decode battery data from manufacturer packets and expose battery voltage and percentage sensors
- document battery encoding and sensor behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b696fcab68832f945f3a820c1c6517