### PR TITLE
Add configurable battery type and precise voltage display

### DIFF
--- a/custom_components/swissinno_ble/config_flow.py
+++ b/custom_components/swissinno_ble/config_flow.py
@@ -89,6 +89,9 @@ class SwissinnoBLEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class SwissinnoBLEOptionsFlow(config_entries.OptionsFlow):
     """Handle options flow for Swissinno BLE."""
 
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self.config_entry = config_entry
+
     async def async_step_init(self, user_input=None):
         """Manage the options."""
         return await self.async_step_user()
@@ -100,9 +103,14 @@ class SwissinnoBLEOptionsFlow(config_entries.OptionsFlow):
 
         data_schema = vol.Schema(
             {
-                vol.Optional("update_interval", default=60): vol.All(
-                    vol.Coerce(int), vol.Range(min=30)
-                )
+                vol.Optional(
+                    "update_interval",
+                    default=self.config_entry.options.get("update_interval", 60),
+                ): vol.All(vol.Coerce(int), vol.Range(min=30)),
+                vol.Optional(
+                    "rechargeable_battery",
+                    default=self.config_entry.options.get("rechargeable_battery", False),
+                ): bool,
             }
         )
 

--- a/custom_components/swissinno_ble/const.py
+++ b/custom_components/swissinno_ble/const.py
@@ -13,8 +13,13 @@ MANUFACTURER_IDS = [0xBB0B, 0x0BBB]
 UNAVAILABLE_AFTER_SECS = 600  # 10 minutes
 
 # Battery voltage range used for percentage calculation
+# Default (alkaline/normal) batteries: 2.0 V -> 0%, 3.0 V -> 100%
 BATTERY_MIN_VOLTAGE = 2.0
-BATTERY_MAX_VOLTAGE = 3.2
+BATTERY_MAX_VOLTAGE = 3.0
+
+# Rechargeable batteries: 1.8 V -> 0%, 2.4 V -> 100%
+BATTERY_MIN_VOLTAGE_RECHARGEABLE = 1.8
+BATTERY_MAX_VOLTAGE_RECHARGEABLE = 2.4
 
 # GATT characteristic holding the trap name
 NAME_CHAR_UUID = "02ecc6cd-2b43-4db5-96e6-ede92cf8778b"


### PR DESCRIPTION
## Summary
- Add decimals and display precision for voltage sensor
- Support rechargeable batteries with configurable voltage range for percentage
- Expose rechargeable battery option in config flow and adjust constants to 2-3V default

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b69f912e44832fbcc1942ececdce81