### PR TITLE
Improve Swissinno reset rediscovery reliability

### DIFF
--- a/custom_components/swissinno_ble/button.py
+++ b/custom_components/swissinno_ble/button.py
@@ -98,12 +98,10 @@ class SwissinnoResetButton(ButtonEntity):
                     try:
                         service_info = await async_process_advertisements(
                             self.hass,
-                            lambda si: bool(
-                                si.manufacturer_data.get(manufacturer_id)
-                            ),
+                            lambda _: True,
                             BluetoothCallbackMatcher(manufacturer_id=manufacturer_id),
                             BluetoothScanningMode.ACTIVE,
-                            5,
+                            15,
                         )
                     except asyncio.TimeoutError:
                         _LOGGER.debug(


### PR DESCRIPTION
## Summary
- relax advertisement filter when rediscovering the trap
- extend rediscovery scan timeout to 15s

## Testing
- `python -m py_compile custom_components/swissinno_ble/button.py`


------
https://chatgpt.com/codex/tasks/task_e_68b73b602c08832f94d461f6841eeb7a