### PR TITLE
fix: ensure manufacturer data during rediscovery

### DIFF
--- a/custom_components/swissinno_ble/button.py
+++ b/custom_components/swissinno_ble/button.py
@@ -98,7 +98,9 @@ class SwissinnoResetButton(ButtonEntity):
                     try:
                         service_info = await async_process_advertisements(
                             self.hass,
-                            lambda _: True,
+                            lambda si: bool(
+                                si.manufacturer_data.get(manufacturer_id)
+                            ),
                             BluetoothCallbackMatcher(manufacturer_id=manufacturer_id),
                             BluetoothScanningMode.ACTIVE,
                             15,


### PR DESCRIPTION
## Summary
- filter for manufacturer data when rediscovering devices to maintain reset capability

## Testing
- `python -m pytest`
- `python -m py_compile custom_components/swissinno_ble/button.py`


------
https://chatgpt.com/codex/tasks/task_e_68b73d603ae0832fa01cec1938ea67a2