### PR TITLE
Filter BLE callbacks by device address

### DIFF
--- a/custom_components/swissinno_ble/sensor.py
+++ b/custom_components/swissinno_ble/sensor.py
@@ -107,7 +107,10 @@ class SwissinnoBLEEntity(SensorEntity):
             async_register_callback(
                 hass,
                 self._async_handle_ble_event,
-                BluetoothCallbackMatcher(manufacturer_id=manufacturer_id),
+                BluetoothCallbackMatcher(
+                    address=address,
+                    manufacturer_id=manufacturer_id,
+                ),
                 BluetoothScanningMode.ACTIVE,
             )
             for manufacturer_id in MANUFACTURER_IDS
@@ -120,6 +123,9 @@ class SwissinnoBLEEntity(SensorEntity):
     ) -> None:
         """Process a Bluetooth event."""
         _LOGGER.debug("Advertisement from %s: %s", service_info.address, service_info)
+
+        if service_info.address.lower() != self._address:
+            return
 
         manufacturer_data = None
         for manufacturer_id in MANUFACTURER_IDS:


### PR DESCRIPTION
## Summary
- Ensure BLE entities only process advertisements from their own device by filtering callbacks by address
- Guard against processing BLE events from mismatched addresses

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7f8177e30832fa04dd495ad6e4b68