### PR TITLE
Remove address filter from BLE callbacks

### DIFF
--- a/custom_components/swissinno_ble/sensor.py
+++ b/custom_components/swissinno_ble/sensor.py
@@ -108,7 +108,6 @@ class SwissinnoBLEEntity(SensorEntity):
                 hass,
                 self._async_handle_ble_event,
                 BluetoothCallbackMatcher(
-                    address=address,
                     manufacturer_id=manufacturer_id,
                 ),
                 BluetoothScanningMode.ACTIVE,
@@ -124,6 +123,8 @@ class SwissinnoBLEEntity(SensorEntity):
         """Process a Bluetooth event."""
         _LOGGER.debug("Advertisement from %s: %s", service_info.address, service_info)
 
+        # Ignore advertisements from other devices; the matcher subscribes
+        # based solely on manufacturer ID
         if service_info.address.lower() != self._address:
             return
 


### PR DESCRIPTION
## Summary
- drop address constraint from Bluetooth callback matcher to avoid missing trap broadcasts
- verify trap address inside callback to ignore other devices

## Testing
- `pytest`
- `ruff check custom_components/swissinno_ble/sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc19eb8fb0832f89d085d61b4d638c