### PR TITLE
Add last update sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ button to remotely reset the trap.
 - Detects trap state via Bluetooth manufacturer data
 - Reset button for supported traps
 - Config flow for easy setup
+- "Last Update" sensor showing when data was last received
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- track wall-clock time of last Bluetooth packet
- expose last update timestamp via new sensor
- document last update sensor in README

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be7746437c832fb0b7f9579352518e