### PR TITLE
Use passive scanning for Swissinno BLE sensors

### DIFF
--- a/custom_components/swissinno_ble/sensor.py
+++ b/custom_components/swissinno_ble/sensor.py
@@ -120,7 +120,7 @@ class SwissinnoBLEEntity(SensorEntity):
                 BluetoothCallbackMatcher(
                     manufacturer_id=manufacturer_id,
                 ),
-                BluetoothScanningMode.ACTIVE,
+                BluetoothScanningMode.PASSIVE,
             )
             for manufacturer_id in MANUFACTURER_IDS
         ]
@@ -218,7 +218,7 @@ class SwissinnoBLEEntity(SensorEntity):
                     BluetoothCallbackMatcher(
                         address=self._address, manufacturer_id=manufacturer_id
                     ),
-                    BluetoothScanningMode.ACTIVE,
+                    BluetoothScanningMode.PASSIVE,
                     15,
                 )
             except asyncio.TimeoutError:


### PR DESCRIPTION
## Summary
- listen passively for Swissinno BLE advertisements
- avoid active scanning so the trap keeps broadcasting, connecting only during resets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68beb23b41d4832fb0e974659702b913