### PR TITLE
Handle passive scanner advertisements with missing manufacturer data

### DIFF
--- a/custom_components/swissinno_ble/sensor.py
+++ b/custom_components/swissinno_ble/sensor.py
@@ -118,7 +118,7 @@ class SwissinnoBLEEntity(SensorEntity):
                 hass,
                 self._async_handle_ble_event,
                 BluetoothCallbackMatcher(address=self._address),
-                BluetoothScanningMode.ACTIVE,
+                BluetoothScanningMode.PASSIVE,
             )
         ]
         self._last_seen: float | None = self._hass.loop.time()
@@ -208,9 +208,10 @@ class SwissinnoBLEEntity(SensorEntity):
         try:
             service_info = await async_process_advertisements(
                 self._hass,
-                lambda si: si.address.lower() == self._address,
+                lambda si: si.address.lower() == self._address
+                and bool(si.manufacturer_data),
                 BluetoothCallbackMatcher(address=self._address),
-                BluetoothScanningMode.ACTIVE,
+                BluetoothScanningMode.PASSIVE,
                 15,
             )
         except asyncio.TimeoutError:


### PR DESCRIPTION
## Summary
- ensure callbacks use passive scanning
- ignore passive advertisements that lack manufacturer data

## Testing
- `pytest`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_68bed524dc54832f8484a64f7eae1d7a