### PR TITLE
Normalize MAC addresses to lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ button to remotely reset the trap.
 
 1. In Home Assistant go to **Settings → Devices & services**.
 2. Click **Add Integration** and search for "Swissinno BLE (Unofficial)".
-3. Enter the name and MAC address of your trap.
+3. Enter the name and MAC address of your trap (case-insensitive).
 
 ## BLE details
 

--- a/custom_components/swissinno_ble/config_flow.py
+++ b/custom_components/swissinno_ble/config_flow.py
@@ -28,7 +28,7 @@ class SwissinnoBLEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            mac_address = format_mac(user_input[CONF_MAC])
+            mac_address = format_mac(user_input[CONF_MAC]).lower()
             name = user_input[CONF_NAME]
 
             if not self._valid_mac(mac_address):
@@ -54,7 +54,7 @@ class SwissinnoBLEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(
                     CONF_MAC,
                     default=(
-                        format_mac(self._discovery_info.address)
+                        format_mac(self._discovery_info.address).lower()
                         if self._discovery_info
                         else ""
                     ),
@@ -70,7 +70,7 @@ class SwissinnoBLEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_bluetooth(self, discovery_info: BluetoothServiceInfoBleak):
         """Handle a bluetooth discovery flow."""
-        await self.async_set_unique_id(format_mac(discovery_info.address), raise_on_progress=False)
+        await self.async_set_unique_id(format_mac(discovery_info.address).lower(), raise_on_progress=False)
         self._abort_if_unique_id_configured()
         self._discovery_info = discovery_info
         self.context["title_placeholders"] = {"name": discovery_info.name or "Mouse Trap"}


### PR DESCRIPTION
## Summary
- Normalize MAC address handling by converting addresses to lowercase during configuration and discovery
- Document that MAC addresses are case-insensitive

## Testing
- `python -m py_compile custom_components/swissinno_ble/config_flow.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfc01081d0832fa37d6b5a8af98a13