### PR TITLE
Log debug output to separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ button to remotely reset the trap.
 - Reset button for supported traps
 - Config flow for easy setup
 - "Last Update" sensor showing when data was last received
-- Optional detailed debug logging for troubleshooting
+- Optional detailed debug logging for troubleshooting (written to `swissinno_ble.log`)
 
 ## Installation
 
@@ -39,7 +39,8 @@ button to remotely reset the trap.
 2. Click **Add Integration** and search for "Swissinno BLE (Unofficial)".
 3. Enter the name and MAC address of your trap (case-insensitive).
 4. Enable **Debug logging** in the integration options if you need detailed
-   information about received Bluetooth data.
+   information about received Bluetooth data. Logs are written to
+   `swissinno_ble.log` in your Home Assistant configuration directory.
 
 ## BLE details
 

--- a/custom_components/swissinno_ble/__init__.py
+++ b/custom_components/swissinno_ble/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.const import Platform
 
-from .const import DOMAIN
+from .const import DOMAIN, LOG_FILE
 
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON]
 
@@ -24,7 +24,21 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Swissinno BLE from a config entry."""
     if entry.options.get("debug_logging"):
-        logging.getLogger(__package__).setLevel(logging.DEBUG)
+        logger = logging.getLogger(__package__)
+        logger.setLevel(logging.DEBUG)
+        log_file = hass.config.path(LOG_FILE)
+        if not any(
+            isinstance(h, logging.FileHandler) and h.baseFilename == log_file
+            for h in logger.handlers
+        ):
+            file_handler = logging.FileHandler(log_file)
+            file_handler.setFormatter(
+                logging.Formatter(
+                    "%(asctime)s %(name)s %(levelname)s: %(message)s"
+                )
+            )
+            logger.addHandler(file_handler)
+        logger.propagate = False
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
@@ -32,5 +46,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload Swissinno BLE config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    result = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    if entry.options.get("debug_logging"):
+        logger = logging.getLogger(__package__)
+        log_file = hass.config.path(LOG_FILE)
+        for handler in list(logger.handlers):
+            if isinstance(handler, logging.FileHandler) and handler.baseFilename == log_file:
+                logger.removeHandler(handler)
+                handler.close()
+        logger.propagate = True
+        logger.setLevel(logging.INFO)
+
+    return result
 

--- a/custom_components/swissinno_ble/const.py
+++ b/custom_components/swissinno_ble/const.py
@@ -5,6 +5,7 @@ any guarantees. Swissinno is a trademark of its respective owner.
 """
 
 DOMAIN = "swissinno_ble"
+LOG_FILE = f"{DOMAIN}.log"
 
 # Manufacturer IDs for Swissinno devices (used for discovery only)
 MANUFACTURER_IDS = [0xBB0B, 0x0BBB]


### PR DESCRIPTION
## Summary
- add constant for integration log file
- route debug logs to `swissinno_ble.log` instead of Home Assistant log
- document log file location in README

## Testing
- `python -m py_compile custom_components/swissinno_ble/const.py custom_components/swissinno_ble/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfcdbd73b0832fa174ae6e9938086b