### PR TITLE
Extend BLE advertisement wait to 60 seconds

### DIFF
--- a/custom_components/swissinno_ble/sensor.py
+++ b/custom_components/swissinno_ble/sensor.py
@@ -227,7 +227,7 @@ class SwissinnoBLEEntity(SensorEntity):
                 and bool(si.manufacturer_data),
                 BluetoothCallbackMatcher(address=self._address),
                 BluetoothScanningMode.ACTIVE,
-                15,
+                60,
             )
         except asyncio.TimeoutError:
             _LOGGER.debug(


### PR DESCRIPTION
## Summary
- Increase BLE advertisement timeout from 15s to 60s when polling for updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c02b71e264832fa86aff4c1d8ceba1