### PR TITLE
feat: expand coordinator debug logging

### DIFF
--- a/custom_components/swissinno_ble/coordinator.py
+++ b/custom_components/swissinno_ble/coordinator.py
@@ -79,6 +79,12 @@ class SwissinnoBLECoordinator(DataUpdateCoordinator[SwissinnoTrapData]):
         """Handle incoming Bluetooth advertisement."""
         manufacturer_data = self._parse_manufacturer_data(service_info)
         if not manufacturer_data:
+            if self.debug:
+                _LOGGER.debug(
+                    "Advertisement from %s ignored: no manufacturer data: %s",
+                    self.address,
+                    service_info,
+                )
             return
         self._process_manufacturer_data(manufacturer_data, service_info.time)
 
@@ -89,6 +95,12 @@ class SwissinnoBLECoordinator(DataUpdateCoordinator[SwissinnoTrapData]):
             manufacturer_data = self._parse_manufacturer_data(info)
             if manufacturer_data:
                 self._process_manufacturer_data(manufacturer_data, info.time)
+            elif self.debug:
+                _LOGGER.debug(
+                    "Cached service info from %s lacked manufacturer data: %s",
+                    self.address,
+                    info,
+                )
             return self.data
 
         try:
@@ -117,6 +129,10 @@ class SwissinnoBLECoordinator(DataUpdateCoordinator[SwissinnoTrapData]):
                         10,
                     )
                 except asyncio.TimeoutError as err2:
+                    if self.debug:
+                        _LOGGER.debug(
+                            "Active scan timed out for %s", self.address
+                        )
                     raise UpdateFailed("No advertisement received") from err2
             else:
                 if self.debug and not self._missing_logged:
@@ -126,6 +142,12 @@ class SwissinnoBLECoordinator(DataUpdateCoordinator[SwissinnoTrapData]):
 
         manufacturer_data = self._parse_manufacturer_data(service_info)
         if not manufacturer_data:
+            if self.debug:
+                _LOGGER.debug(
+                    "Advertisement from %s lacked manufacturer data: %s",
+                    self.address,
+                    service_info,
+                )
             raise UpdateFailed("Advertisement lacked manufacturer data")
         self._process_manufacturer_data(manufacturer_data, service_info.time)
         return self.data


### PR DESCRIPTION
## Summary
- improve BLE coordinator logging when manufacturer data is missing
- report active scan timeouts for deeper diagnostics

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6d50357bc832f994cba372b7aabe5