### PR TITLE
Add MQTT sensors for agent outputs

### DIFF
--- a/custom_components/swissinno_ble/manifest.json
+++ b/custom_components/swissinno_ble/manifest.json
@@ -7,7 +7,7 @@
   "requirements": [
     "bleak>=0.20.2"
   ],
-  "dependencies": ["bluetooth"],
+  "dependencies": ["bluetooth", "mqtt"],
   "codeowners": ["@yourusername"],
   "config_flow": true,
   "iot_class": "local_push",

--- a/custom_components/swissinno_ble/sensor.py
+++ b/custom_components/swissinno_ble/sensor.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Callable
 from datetime import datetime
 
+from homeassistant.components import mqtt
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -15,13 +18,37 @@ from homeassistant.const import (
     PERCENTAGE,
     UnitOfElectricPotential,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
+from homeassistant.components.mqtt.models import ReceiveMessage
 
 from .const import DOMAIN
 from .coordinator import SwissinnoBLECoordinator
 from .entity import SwissinnoBLEEntity
+
+
+_LOGGER = logging.getLogger(__name__)
+
+OUTPUT_SENSORS: tuple[tuple[str, str, str], ...] = (
+    (
+        "Oracle Last Prediction",
+        "oracle_last_prediction",
+        "trinitygrid/oracle/prediction",
+    ),
+    (
+        "General Last Decision",
+        "general_last_decision",
+        "trinitygrid/general/decision",
+    ),
+    (
+        "Justice Last Report",
+        "justice_last_report",
+        "trinitygrid/justice/report",
+    ),
+)
 
 
 async def async_setup_entry(
@@ -39,6 +66,18 @@ async def async_setup_entry(
         SwissinnoBLELastUpdateSensor(coordinator, name),
         SwissinnoBLERawBeaconSensor(coordinator, name),
     ]
+
+    sensors.extend(
+        SwissinnoBLEAgentOutputSensor(
+            hass,
+            coordinator,
+            name,
+            sensor_name,
+            unique_suffix,
+            topic,
+        )
+        for sensor_name, unique_suffix, topic in OUTPUT_SENSORS
+    )
     async_add_entities(sensors)
 
 
@@ -93,4 +132,71 @@ class SwissinnoBLELastUpdateSensor(SwissinnoBLEEntity, SensorEntity):
     @property
     def native_value(self) -> datetime | None:  # type: ignore[override]
         return self.coordinator.data.last_update
+
+
+class SwissinnoBLEAgentOutputSensor(SensorEntity):
+    """Sensor that exposes the latest agent output published via MQTT."""
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: SwissinnoBLECoordinator,
+        device_name: str,
+        name: str,
+        unique_suffix: str,
+        topic: str,
+    ) -> None:
+        self.hass = hass
+        self._topic = topic
+        self._unsubscribe: Callable[[], None] | None = None
+        self._available = False
+        self._attr_name = name
+        self._attr_native_value: str | None = None
+        self._attr_unique_id = f"{coordinator.address}_{unique_suffix}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.address)},
+            name=device_name,
+            manufacturer="Swissinno (unofficial)",
+            model="Mouse Trap",
+        )
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+
+        try:
+            await mqtt.async_wait_for_mqtt_client(self.hass)
+        except HomeAssistantError as err:
+            _LOGGER.error(
+                "Unable to subscribe to %s because MQTT client is not available: %s",
+                self._topic,
+                err,
+            )
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        self._unsubscribe = await mqtt.async_subscribe(
+            self.hass,
+            self._topic,
+            self._message_received,
+        )
+        self._available = True
+        self.async_write_ha_state()
+
+    async def async_will_remove_from_hass(self) -> None:
+        await super().async_will_remove_from_hass()
+        if self._unsubscribe:
+            self._unsubscribe()
+            self._unsubscribe = None
+
+    @callback
+    def _message_received(self, message: ReceiveMessage) -> None:
+        self._attr_native_value = message.payload
+        self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        return self._available
 


### PR DESCRIPTION
## Summary
- add MQTT-based sensors that expose the oracle, general, and justice outputs
- subscribe to the retained topics so Home Assistant restores the documented entities
- declare a dependency on the MQTT integration so the sensors can connect reliably

## Testing
- python -m compileall custom_components/swissinno_ble

------
https://chatgpt.com/codex/tasks/task_e_68ca2fef17c8832fbfad1c78679c3467